### PR TITLE
Fix some byte-compile warnings

### DIFF
--- a/company-suggest.el
+++ b/company-suggest.el
@@ -55,11 +55,11 @@
 		  (lambda (buffer)
 		    (funcall callback
 			     (prog1
-				 (remove-if-not (lambda  (s)
-						  (string-prefix-p prefix s t))
-						(mapcar (lambda (node)
-							  (decode-coding-string  (xml-get-attribute (car (xml-get-children node 'suggestion)) 'data) 'utf-8))
-							(xml-get-children (car (xml-parse-region (point-min) (point-max))) 'CompleteSuggestion)))
+				 (cl-remove-if-not (lambda  (s)
+						     (string-prefix-p prefix s t))
+						   (mapcar (lambda (node)
+							     (decode-coding-string  (xml-get-attribute (car (xml-get-children node 'suggestion)) 'data) 'utf-8))
+							   (xml-get-children (car (xml-parse-region (point-min) (point-max))) 'CompleteSuggestion)))
 			       (kill-buffer))))
 		  nil t)))
 

--- a/company-suggest.el
+++ b/company-suggest.el
@@ -31,6 +31,7 @@
 (require 'mm-url)
 (require 'cl-lib)
 (require 'thingatpt)
+(require 'json)
 
 (defgroup company-suggest '()
   "Customization group for `company-suggest'."


### PR DESCRIPTION
```
company-suggest.el:98:1:Warning: Unused lexical variable ‘json-key-type’
company-suggest.el:98:1:Warning: Unused lexical variable ‘json-object-type’
company-suggest.el:98:1:Warning: Unused lexical variable ‘json-array-type’

In end of data:
company-suggest.el:122:1:Warning: the following functions are not known to be defined: remove-if-not,
    json-read-from-string
```